### PR TITLE
Change the name of the build directories from build_ to kinkal_ .

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ This will do the following
 When this is complete you will see the following subdirectories of clean_working_dir
 * KinKal_to_UPS - this package
 * KinKal        - the cloned source
-* build_profile - the working space for the Release (prof) build
-* build_debug   - the working space for the Debug (debug) build
+* kinkal_profile - the working space for the Release (prof) build
+* kinkal_debug   - the working space for the Debug (debug) build
 * artexternals  - the UPS repo into which the code is installed.
 
 You will also see two files:
@@ -78,7 +78,7 @@ These tar.bz2 files are formatted to be unwound into /cvmfs/mu2e.opensciencegrid
 
 You can point the UPS repo at an arbitrary directory using the -d option but the other four directory names are hard coded.
 
-The default behaviour is to abort if the KinKal directory already exists; it will overwrite existing files in build_profile, build_debug
+The default behaviour is to abort if the KinKal directory already exists; it will overwrite existing files in kinkal_profile, kinkal_debug
 and artexternals/KinKal.
 
 ## Fixmes, Todos and questions
@@ -91,7 +91,7 @@ and artexternals/KinKal.
 * Should KinKal_to_UPS be installed in UPS?
 * In the case of installing a prebuilt version of KinKal, is there a way to automatically determine the git tag so that it does not need to be given by hand in the install command?
 * Add an option to add additional qualifiers to the KinKal product
-* Is it OK that the names build_profile, build_debug are hard coded?  If not, we can make options to define them.
+* Is it OK that the names kinkal_profile, kinkal_debug are hard coded?  If not, we can make options to define them.
 * What additional checks for corner cases are needed?
 * I need to roll up the return statuses to one overall exit status and update the exit message.
 * Rename the tar.bz2 files to match the scisoft standard.

--- a/build
+++ b/build
@@ -203,8 +203,8 @@ makeTarFiles() {
 
 productName=KinKal
 
-buildDirProf="build_profile"
-buildDirDebug="build_debug"
+buildDirProf="kinkal_profile"
+buildDirDebug="kinkal_debug"
 
 # The directory that contains this script (and others that it will run).
 thisDir=`dirname $(readlink -f $0)`
@@ -319,13 +319,13 @@ if [ -n "$doBuild" ]; then
     exit 3
   fi
   if [[ -n "${doProf}" ]]; then
-    ${thisDir}/build_one_version ${cmakever} "${rootVer} -q${plusProfRootQuals}" ${nBuildThreads} ${doTest}
+    ${thisDir}/build_one_version ${cmakever} "${rootVer} -q${plusProfRootQuals}" ${buildDirProf} ${nBuildThreads} ${doTest}
     if [[ "$?" != "0" ]]; then
        exit 4
     fi
   fi
   if [[ -n "${doDebug}" ]]; then
-    ${thisDir}/build_one_version ${cmakever} "${rootVer} -q${plusDebugRootQuals}" ${nBuildThreads} ${doTest}
+    ${thisDir}/build_one_version ${cmakever} "${rootVer} -q${plusDebugRootQuals}" ${buildDirDebug} ${nBuildThreads} ${doTest}
     if [[ "$?" != "0" ]]; then
        exit 5
     fi

--- a/build_one_version
+++ b/build_one_version
@@ -8,17 +8,19 @@
 # Arguments
 # cmakever             = version + qualifer string for cmake
 # root_for_this_build  = version + qualifier string for root
+# local_build_dir      = directory that will hold the build
 # nbuildthreads        = number of threads to use for make
 # dotest               = if true then do the tests after the build
 
 cmake_ver=$1
 root_for_this_build=$2
-nbuildthreads=$3
-dotest=$4
+local_build_dir=$3
+nbuildthreads=$4
+dotest=$5
 
 # The convention suggested in the KinKal docs is that
-#  cmake build type Release is built in the directory build_profile
-#  cmake build type Debug is built in the directory build_debug
+#  cmake build type Release is built in the directory kinkal_profile
+#  cmake build type Debug is built in the directory kinkal_debug
 cmake_build_type=""
 local_build_suffix=""
 if grep -q "prof"  <<< "$root_for_this_build"; then
@@ -46,8 +48,8 @@ if [[ "$?" != "0" ]]; then
 fi
 ups active
 
-mkdir -p build_${local_build_suffix}
-cd build_${local_build_suffix}
+mkdir -p ${local_build_dir}
+cd ${local_build_dir}
 cmake ../KinKal  -DCMAKE_BUILD_TYPE=${cmake_build_type}
 if [[ "$?" != "0" ]]; then
   exit 4


### PR DESCRIPTION
This is needed to match a change of conventions in the recommended workflow for building KinKal.

I tested two workflows.  First: expect prebuilt code with a root version in the environment; then do an install and produce the .bz2 file for one of prof/debug.  Second: expect a clean environment; do everything starting from clone.  
