### PR TITLE
Add more pathPrepend lines for ROOT_INCLUDE_PATH.

### DIFF
--- a/installTableFile
+++ b/installTableFile
@@ -107,6 +107,9 @@ Common:
 
     envSet (KINKAL_INC, \${KINKAL_DIR}/include )
     pathPrepend(ROOT_INCLUDE_PATH, \${KINKAL_DIR}/include)
+    pathPrepend(ROOT_INCLUDE_PATH, \${KINKAL_DIR}/include/KinKal/General)
+    pathPrepend(ROOT_INCLUDE_PATH, \${KINKAL_DIR}/include/KinKal/Trajectory)
+    pathPrepend(ROOT_INCLUDE_PATH, \${KINKAL_DIR}/include/KinKal/Examples)
 
     exeActionRequired(GetFQDir)
     envSet (KINKAL_LIB, \${KINKAL_DIR}/\${KINKAL_FQ}/lib )


### PR DESCRIPTION
These are needed because the header lines in the rootmap files contain only
the file name, not the path relative to the package root.  I have
a question in to the root experts to learn how to teach rootcling to write
header lines with the relative path. If that converges we can remove these
pathPrepend lines.